### PR TITLE
Fix block class in layout

### DIFF
--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -2,7 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="content">
-            <block class="\Magento\Framework\View\Element\Template" name="estimaterate.js" template="Eniture_WweLtlFreightQuotes::estimaterate.phtml" cacheable="false" after="shipping"/>
+            <block class="Magento\Framework\View\Element\Template" name="estimaterate.js" template="Eniture_WweLtlFreightQuotes::estimaterate.phtml" cacheable="false" after="shipping"/>
         </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
The block class is not allowed to have a preceding slash. This breaks the cart page.